### PR TITLE
Syntax Processing Capabilities for more stable form building

### DIFF
--- a/core/src/main/java/me/naingaungluu/formconductor/annotations/EmailAddress.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/annotations/EmailAddress.kt
@@ -13,5 +13,8 @@ import me.naingaungluu.formconductor.validation.rules.EmailAddressRule
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)
 @MustBeDocumented
-@FieldValidation<String>(EmailAddressRule::class)
+@FieldValidation<String>(
+    fieldType = String::class,
+    validator = EmailAddressRule::class
+)
 annotation class EmailAddress()

--- a/core/src/main/java/me/naingaungluu/formconductor/annotations/FieldValidation.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/annotations/FieldValidation.kt
@@ -15,6 +15,7 @@ import kotlin.reflect.KClass
 @Target(AnnotationTarget.ANNOTATION_CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 @MustBeDocumented
-annotation class FieldValidation<T : Any?>(
+annotation class FieldValidation<T : Any>(
+    val fieldType: KClass<T>,
     val validator: KClass<out ValidationRule<T, *>>
 )

--- a/core/src/main/java/me/naingaungluu/formconductor/annotations/FloatRange.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/annotations/FloatRange.kt
@@ -19,7 +19,10 @@ import me.naingaungluu.formconductor.validation.rules.FloatRangeRule
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)
 @MustBeDocumented
-@FieldValidation<Float>(FloatRangeRule::class)
+@FieldValidation<Float>(
+    fieldType = Float::class,
+    validator = FloatRangeRule::class
+)
 annotation class FloatRange(
     val min: Double,
     val max: Double

--- a/core/src/main/java/me/naingaungluu/formconductor/annotations/IntegerRange.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/annotations/IntegerRange.kt
@@ -20,7 +20,10 @@ import me.naingaungluu.formconductor.validation.rules.IntegerRangeRule
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)
 @MustBeDocumented
-@FieldValidation<Int>(IntegerRangeRule::class)
+@FieldValidation<Int>(
+    fieldType = Int::class,
+    validator = IntegerRangeRule::class
+)
 annotation class IntegerRange(
     val min: Int,
     val max: Int

--- a/core/src/main/java/me/naingaungluu/formconductor/annotations/IsChecked.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/annotations/IsChecked.kt
@@ -19,5 +19,8 @@ import me.naingaungluu.formconductor.validation.rules.IsCheckedRule
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)
 @MustBeDocumented
-@FieldValidation<Boolean>(IsCheckedRule::class)
+@FieldValidation<Boolean>(
+    fieldType = Boolean::class,
+    validator = IsCheckedRule::class
+)
 annotation class IsChecked

--- a/core/src/main/java/me/naingaungluu/formconductor/annotations/MaxLength.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/annotations/MaxLength.kt
@@ -18,5 +18,8 @@ import me.naingaungluu.formconductor.validation.rules.MaxLengthRule
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)
 @MustBeDocumented
-@FieldValidation<String>(MaxLengthRule::class)
+@FieldValidation<String>(
+    fieldType = String::class,
+    validator = MaxLengthRule::class
+)
 annotation class MaxLength(val value: Int)

--- a/core/src/main/java/me/naingaungluu/formconductor/annotations/MinLength.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/annotations/MinLength.kt
@@ -18,5 +18,8 @@ import me.naingaungluu.formconductor.validation.rules.MinLengthRule
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)
 @MustBeDocumented
-@FieldValidation<String>(MinLengthRule::class)
+@FieldValidation<String>(
+    fieldType = String::class,
+    validator = MinLengthRule::class
+)
 annotation class MinLength(val value: Int)

--- a/core/src/main/java/me/naingaungluu/formconductor/annotations/Optional.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/annotations/Optional.kt
@@ -16,5 +16,4 @@ import me.naingaungluu.formconductor.validation.rules.OptionalRule
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)
 @MustBeDocumented
-@FieldValidation<Any?>(OptionalRule::class)
 annotation class Optional

--- a/core/src/main/java/me/naingaungluu/formconductor/annotations/WebUrl.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/annotations/WebUrl.kt
@@ -19,7 +19,10 @@ import me.naingaungluu.formconductor.validation.rules.WebUrlRule
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)
 @MustBeDocumented
-@FieldValidation<String>(WebUrlRule::class)
+@FieldValidation<String>(
+    fieldType = String::class,
+    validator = WebUrlRule::class
+)
 annotation class WebUrl(
     val httpRequired: Boolean = false
 )

--- a/core/src/main/java/me/naingaungluu/formconductor/syntax/AnnotationSyntaxProcessor.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/syntax/AnnotationSyntaxProcessor.kt
@@ -1,0 +1,40 @@
+package me.naingaungluu.formconductor.syntax
+
+import me.naingaungluu.formconductor.annotations.FieldValidation
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.hasAnnotation
+import kotlin.reflect.jvm.javaField
+import kotlin.reflect.jvm.jvmName
+
+/**
+ * A syntax processor to check type compatibility with fields
+ *
+ */
+class AnnotationSyntaxProcessor : SyntaxProcessor {
+    override fun <T : Any, V : Any?> process(field: KProperty1<T, V>): SyntaxResult {
+        val fieldValidationAnnotations = field.annotations.filter {
+            it.annotationClass.hasAnnotation<FieldValidation<*>>()
+        }
+        val result = fieldValidationAnnotations.map {
+            val validationAnnotation = it.annotationClass.findAnnotation<FieldValidation<*>>()
+            val allowedTypeName = validationAnnotation?.fieldType?.jvmName
+            val receivedTypeName = field.javaField?.type?.name
+            if (allowedTypeName == receivedTypeName) {
+                SyntaxResult.Success
+            } else {
+                SyntaxResult.Error.InvalidType(
+                    receivedType = receivedTypeName.toString(),
+                    expectedType = allowedTypeName.toString(),
+                    annotationName = it.annotationClass.simpleName.toString()
+                )
+            }
+        }
+        val syntaxSatisfied = result.all { it is SyntaxResult.Success }
+        return if (syntaxSatisfied) {
+            SyntaxResult.Success
+        } else {
+            result.first { it is SyntaxResult.Error }
+        }
+    }
+}

--- a/core/src/main/java/me/naingaungluu/formconductor/syntax/SyntaxProcessor.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/syntax/SyntaxProcessor.kt
@@ -1,0 +1,7 @@
+package me.naingaungluu.formconductor.syntax
+
+import kotlin.reflect.KProperty1
+
+interface SyntaxProcessor {
+    fun <T : Any, V : Any?> process(field: KProperty1<T, V>): SyntaxResult
+}

--- a/core/src/main/java/me/naingaungluu/formconductor/syntax/SyntaxResult.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/syntax/SyntaxResult.kt
@@ -1,0 +1,33 @@
+package me.naingaungluu.formconductor.syntax
+
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty
+
+/**
+ * Result types for Syntax Processor
+ *
+ */
+sealed class SyntaxResult {
+    /**
+     * Successful syntax
+     */
+    object Success : SyntaxResult()
+
+    /**
+     * Erroneous Syntax with failed constraints
+     */
+    sealed class Error : SyntaxResult() {
+        /**
+         * This error is thrown when an incompatible validator annotation is applied to a field
+         *
+         * @property expectedType allowed type by the annotation
+         * @property receivedType actual type of the field
+         * @property annotationName name of the annotation applied
+         */
+        data class InvalidType(
+            val expectedType: String,
+            val receivedType: String,
+            val annotationName: String
+        ) : Error()
+    }
+}

--- a/core/src/main/java/me/naingaungluu/formconductor/syntax/SyntaxUtils.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/syntax/SyntaxUtils.kt
@@ -1,0 +1,29 @@
+package me.naingaungluu.formconductor.syntax
+
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty
+
+
+/**
+ * A Helpful util function to produce proper error message
+ *
+ * @param T form class type
+ * @param V field type
+ * @param formClass KClass reference of the form class
+ * @param field KProperty reference of the field
+ * @return Error message string
+ */
+fun <T : Any, V : Any?> SyntaxResult.Error.getErrorMessage(
+    formClass: KClass<T>,
+    field: KProperty<V>
+): String {
+    return when (this) {
+        is SyntaxResult.Error.InvalidType -> {
+            """
+                ERROR WHILE CONSTRUCTING FORM: ${formClass.simpleName}.
+                Field type constraints failed.
+                Validation Annotation `$annotationName` for type $expectedType cannot be applied to field `${field.name}` of type $receivedType
+            """.trimIndent()
+        }
+    }
+}


### PR DESCRIPTION
Implemented the followings:
- `SyntaxProcessor`
- `Annotation Syntax Processor`
- `SyntaxResult` types

Updated `FormImpl` to use syntax processing checks before form initialization