### PR TITLE
Stateless and State based validation rules

### DIFF
--- a/core/src/main/java/me/naingaungluu/formconductor/CollectableFormData.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/CollectableFormData.kt
@@ -1,0 +1,5 @@
+package me.naingaungluu.formconductor
+
+interface CollectableFormData<T: Any> {
+    fun collectFormData(): T
+}

--- a/core/src/main/java/me/naingaungluu/formconductor/FieldResult.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/FieldResult.kt
@@ -21,7 +21,7 @@ sealed class FieldResult {
      */
     data class Error(
         val message: String,
-        val failedRule: ValidationRule<*, *>
+        val failedRule: ValidationRule
     ) : FieldResult()
 
     /**

--- a/core/src/main/java/me/naingaungluu/formconductor/FormFieldImpl.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/FormFieldImpl.kt
@@ -1,7 +1,8 @@
 package me.naingaungluu.formconductor
 
 import kotlinx.coroutines.flow.MutableStateFlow
-import me.naingaungluu.formconductor.validation.FieldValidator
+import me.naingaungluu.formconductor.validation.validators.FieldValidator
+import me.naingaungluu.formconductor.validation.validators.StatelessFieldValidator
 import me.naingaungluu.formconductor.validation.rules.OptionalRule
 import kotlin.reflect.KProperty1
 
@@ -11,12 +12,12 @@ import kotlin.reflect.KProperty1
  * @param T Receiver type or the Form Data class.
  * @param V Type of the field
  * @property fieldClass kotlin property reference to the associated property of the field
- * @property validators a set of [FieldValidator] objects associated with the field
+ * @property validators a set of [StatelessFieldValidator] objects associated with the field
  * @property isOptional flags the field as optional
  */
 internal class FormFieldImpl<T : Any, V : Any>(
     private val fieldClass: KProperty1<T, V>,
-    private val validators: Set<FieldValidator<V, *>> = emptySet(),
+    private val validators: Set<FieldValidator<V>> = emptySet(),
     override val isOptional: Boolean = false
 ) : FormField<V> {
 

--- a/core/src/main/java/me/naingaungluu/formconductor/FormResult.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/FormResult.kt
@@ -1,5 +1,6 @@
 package me.naingaungluu.formconductor
 
+import me.naingaungluu.formconductor.validation.StatelessValidationRule
 import me.naingaungluu.formconductor.validation.ValidationRule
 
 /**
@@ -25,7 +26,7 @@ sealed class FormResult<out T : Any> {
      * @property failedRules contains a set of failed validation rules with error messages
      */
     data class Error(
-        val failedRules: Set<ValidationRule<*, *>>
+        val failedRules: Set<ValidationRule>
     ) : FormResult<Nothing>()
 
     /**

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/StateBasedValidationRule.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/StateBasedValidationRule.kt
@@ -1,0 +1,7 @@
+package me.naingaungluu.formconductor.validation
+
+import me.naingaungluu.formconductor.FieldResult
+
+interface StateBasedValidationRule<V : Any?, A : Annotation, T : Any> : ValidationRule {
+    fun validate(value: V, options: A, formState: T): FieldResult
+}

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/StatelessValidationRule.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/StatelessValidationRule.kt
@@ -1,0 +1,16 @@
+package me.naingaungluu.formconductor.validation
+
+import me.naingaungluu.formconductor.FieldResult
+
+/**
+ * Stateless Validation Rule interface
+ *
+ * You can implement this interface to create custom validation rules
+ * that doesn't depend on form state
+ *
+ * @param T Type of value
+ * @param A Type of associated annotation class
+ */
+interface StatelessValidationRule<T : Any?, A : Annotation>: ValidationRule {
+    fun validate(value: T, options: A): FieldResult
+}

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/ValidationRule.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/ValidationRule.kt
@@ -1,15 +1,3 @@
 package me.naingaungluu.formconductor.validation
 
-import me.naingaungluu.formconductor.FieldResult
-
-/**
- * Validation Rule interface
- *
- * You can implement this interface to create custom validation rules
- *
- * @param T Type of value
- * @param A Type of associated annotation class
- */
-interface ValidationRule<T : Any?, A : Annotation> {
-    fun validate(value: T, options: A): FieldResult
-}
+interface ValidationRule

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/rules/EmailAddressRule.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/rules/EmailAddressRule.kt
@@ -2,7 +2,7 @@ package me.naingaungluu.formconductor.validation.rules
 
 import me.naingaungluu.formconductor.FieldResult
 import me.naingaungluu.formconductor.annotations.EmailAddress
-import me.naingaungluu.formconductor.validation.ValidationRule
+import me.naingaungluu.formconductor.validation.StatelessValidationRule
 
 /**
  * Validation Rule for Email Addresses
@@ -13,7 +13,7 @@ import me.naingaungluu.formconductor.validation.ValidationRule
  * @author Naing Aung Luu
  * @since 0.0.1
  */
-object EmailAddressRule : ValidationRule<String, EmailAddress> {
+object EmailAddressRule : StatelessValidationRule<String, EmailAddress> {
 
     /**
      * Custom baked email pattern that allows name@domain.postfix

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/rules/FloatRangeRule.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/rules/FloatRangeRule.kt
@@ -2,7 +2,7 @@ package me.naingaungluu.formconductor.validation.rules
 
 import me.naingaungluu.formconductor.FieldResult
 import me.naingaungluu.formconductor.annotations.FloatRange
-import me.naingaungluu.formconductor.validation.ValidationRule
+import me.naingaungluu.formconductor.validation.StatelessValidationRule
 
 /**
  * Validation Rule for Ranged Float Values
@@ -14,7 +14,7 @@ import me.naingaungluu.formconductor.validation.ValidationRule
  * @author Naing Aung Luu
  * @since 0.0.1
  */
-object FloatRangeRule : ValidationRule<Float, FloatRange> {
+object FloatRangeRule : StatelessValidationRule<Float, FloatRange> {
 
     /**
      * Validates the field using the options passed to the [FloatRange] annotation

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/rules/IntegerRangeRule.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/rules/IntegerRangeRule.kt
@@ -3,7 +3,7 @@ package me.naingaungluu.formconductor.validation.rules
 import me.naingaungluu.formconductor.FieldResult
 import me.naingaungluu.formconductor.annotations.FloatRange
 import me.naingaungluu.formconductor.annotations.IntegerRange
-import me.naingaungluu.formconductor.validation.ValidationRule
+import me.naingaungluu.formconductor.validation.StatelessValidationRule
 
 /**
  * Validation Rule for Ranged Integer Values
@@ -15,7 +15,7 @@ import me.naingaungluu.formconductor.validation.ValidationRule
  * @author Naing Aung Luu
  * @since 0.0.1
  */
-object IntegerRangeRule : ValidationRule<Int, IntegerRange> {
+object IntegerRangeRule : StatelessValidationRule<Int, IntegerRange> {
 
     /**
      * Validates the field using the options passed to the [FloatRange] annotation

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/rules/IsCheckedRule.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/rules/IsCheckedRule.kt
@@ -2,7 +2,7 @@ package me.naingaungluu.formconductor.validation.rules
 
 import me.naingaungluu.formconductor.FieldResult
 import me.naingaungluu.formconductor.annotations.IsChecked
-import me.naingaungluu.formconductor.validation.ValidationRule
+import me.naingaungluu.formconductor.validation.StatelessValidationRule
 
 /**
  * Validation Rule for Checkboxes
@@ -14,7 +14,7 @@ import me.naingaungluu.formconductor.validation.ValidationRule
  * @author Naing Aung Luu
  * @since 0.0.1
  */
-object IsCheckedRule : ValidationRule<Boolean, IsChecked> {
+object IsCheckedRule : StatelessValidationRule<Boolean, IsChecked> {
 
     /**
      * Validates the field if it's checked

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/rules/MaxLengthRule.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/rules/MaxLengthRule.kt
@@ -1,9 +1,8 @@
 package me.naingaungluu.formconductor.validation.rules
 
 import me.naingaungluu.formconductor.FieldResult
-import me.naingaungluu.formconductor.annotations.IsChecked
 import me.naingaungluu.formconductor.annotations.MaxLength
-import me.naingaungluu.formconductor.validation.ValidationRule
+import me.naingaungluu.formconductor.validation.StatelessValidationRule
 
 /**
  * Validation Rule for String Lengths
@@ -17,7 +16,7 @@ import me.naingaungluu.formconductor.validation.ValidationRule
  * @author Naing Aung Luu
  * @since 0.0.1
  */
-object MaxLengthRule : ValidationRule<String, MaxLength> {
+object MaxLengthRule : StatelessValidationRule<String, MaxLength> {
 
     /**
      * Validates the field using the options passed to [MaxLength] annotation

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/rules/MinLengthRule.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/rules/MinLengthRule.kt
@@ -3,7 +3,7 @@ package me.naingaungluu.formconductor.validation.rules
 import me.naingaungluu.formconductor.FieldResult
 import me.naingaungluu.formconductor.annotations.MaxLength
 import me.naingaungluu.formconductor.annotations.MinLength
-import me.naingaungluu.formconductor.validation.ValidationRule
+import me.naingaungluu.formconductor.validation.StatelessValidationRule
 
 /**
  * Validation Rule for String Lengths
@@ -17,7 +17,7 @@ import me.naingaungluu.formconductor.validation.ValidationRule
  * @author Naing Aung Luu
  * @since 0.0.1
  */
-object MinLengthRule : ValidationRule<String, MinLength> {
+object MinLengthRule : StatelessValidationRule<String, MinLength> {
 
     /**
      * Validates the field using the options passed to [MaxLength] annotation

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/rules/OptionalRule.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/rules/OptionalRule.kt
@@ -2,7 +2,7 @@ package me.naingaungluu.formconductor.validation.rules
 
 import me.naingaungluu.formconductor.FieldResult
 import me.naingaungluu.formconductor.annotations.Optional
-import me.naingaungluu.formconductor.validation.ValidationRule
+import me.naingaungluu.formconductor.validation.StatelessValidationRule
 
 /**
  * Validation Rule for Optional Fields
@@ -14,7 +14,7 @@ import me.naingaungluu.formconductor.validation.ValidationRule
  * @author Naing Aung Luu
  * @since 0.0.1
  */
-object OptionalRule : ValidationRule<Any?, Optional> {
+object OptionalRule : StatelessValidationRule<Any?, Optional> {
     // Nothing much here
     override fun validate(value: Any?, options: Optional): FieldResult {
         return FieldResult.Success

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/rules/WebUrlRule.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/rules/WebUrlRule.kt
@@ -4,7 +4,7 @@ import me.naingaungluu.formconductor.FieldResult
 import me.naingaungluu.formconductor.annotations.MaxLength
 import me.naingaungluu.formconductor.annotations.MinLength
 import me.naingaungluu.formconductor.annotations.WebUrl
-import me.naingaungluu.formconductor.validation.ValidationRule
+import me.naingaungluu.formconductor.validation.StatelessValidationRule
 
 /**
  * Validation Rule for String Lengths
@@ -17,7 +17,7 @@ import me.naingaungluu.formconductor.validation.ValidationRule
  * @author Naing Aung Luu
  * @since 0.0.1
  */
-object WebUrlRule : ValidationRule<String, WebUrl> {
+object WebUrlRule : StatelessValidationRule<String, WebUrl> {
 
     /**
      * Custom baked url pattern without a scheme prefix, "https" or "http"

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/validators/FieldValidator.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/validators/FieldValidator.kt
@@ -1,0 +1,7 @@
+package me.naingaungluu.formconductor.validation.validators
+
+import me.naingaungluu.formconductor.FieldResult
+
+internal abstract class FieldValidator<V: Any?> {
+    abstract fun validate(input: V): FieldResult
+}

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/validators/StateBasedValidator.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/validators/StateBasedValidator.kt
@@ -1,0 +1,28 @@
+package me.naingaungluu.formconductor.validation.validators
+
+import me.naingaungluu.formconductor.CollectableFormData
+import me.naingaungluu.formconductor.FieldResult
+import me.naingaungluu.formconductor.validation.StateBasedValidationRule
+
+/**
+ * This is a wrapper class for a [StateBasedValidationRule] instance.
+ * This class makes the validation rules to be reused on the same form instance,
+ * without having to re-specify the options.
+ *
+ * The class automatically provides the options and
+ * current state of the form whenever a validation occurs
+ *
+ * @param form parent form as a [CollectableFormData]
+ * @param validationRule [StateBasedValidationRule] instance to be wrapped
+ * @param options validation parameters required by the rule
+ */
+
+internal class StateBasedFieldValidator<T: Any, V: Any?, A: Annotation>(
+    private val form: CollectableFormData<T>,
+    private val validationRule: StateBasedValidationRule<V, A, T>,
+    private val options: A
+) : FieldValidator<V>() {
+    override fun validate(input: V): FieldResult {
+        return validationRule.validate(input, options, form.collectFormData())
+    }
+}

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/validators/StatelessFieldValidator.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/validators/StatelessFieldValidator.kt
@@ -1,30 +1,31 @@
-package me.naingaungluu.formconductor.validation
+package me.naingaungluu.formconductor.validation.validators
 
 import me.naingaungluu.formconductor.FieldResult
+import me.naingaungluu.formconductor.validation.StatelessValidationRule
 
 /**
  * A wrapper class or proxy that passes the annotation object as options to the validation rule
  *
- * This is especially useful for [FormField] instances to be reused outside of the library,
+ * This is especially useful for form fields to be reused outside of the library,
  * since the call site doesn't have to know about the options.
  *
- * @param T Type of Field Value
+ * @param V Type of Field Value
  * @param A Type of the annotation
  *
  * @property validationRule rule object
  * @property options annotation object
  */
-internal class FieldValidator<T : Any?, A : Annotation>(
-    private val validationRule: ValidationRule<T, A>,
+internal class StatelessFieldValidator<V : Any?, A : Annotation>(
+    private val validationRule: StatelessValidationRule<V, A>,
     private val options: A
-) {
+) : FieldValidator<V>() {
     /**
      * Validates the field using just it's value, since the option is known
      *
-     * @param input value of type [T]
+     * @param input value of type [V]
      * @return
      */
-    fun validate(input: T): FieldResult {
+    override fun validate(input: V): FieldResult {
         return validationRule.validate(input, options)
     }
 }

--- a/sample-compose/src/main/java/me/naingaungluu/formvalidation/screens/FormScreen.kt
+++ b/sample-compose/src/main/java/me/naingaungluu/formvalidation/screens/FormScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectableGroup
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
@@ -13,7 +12,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -70,7 +68,9 @@ fun FormScreen() {
                 TextField(
                     value = state.value?.value.orEmpty(),
                     onValueChange = { setField(it.ifEmpty { null }) },
-                    modifier = Modifier.padding(horizontal = 20.dp).padding(top = 20.dp),
+                    modifier = Modifier
+                        .padding(horizontal = 20.dp)
+                        .padding(top = 20.dp),
                     label = { Text("Name") },
                     isError = resultState.value is me.naingaungluu.formconductor.FieldResult.Error
                 )
@@ -114,7 +114,10 @@ fun FormScreen() {
                 }
             }
             field(SignUpFormData::gender) {
-                Row(Modifier.padding(20.dp).selectableGroup()) {
+                Row(
+                    Modifier
+                        .padding(20.dp)
+                        .selectableGroup()) {
                     RadioButton(
                         selected = state.value?.value == Gender.Male,
                         onClick = { setField(Gender.Male) },


### PR DESCRIPTION
We can now use two different types of validation rules namely the `StatelessValidationRule` and `StateBasedValidationRule`, where the former will validate just the input and the latter will include form's current data while validating. Library consumers can now decide on whether to use form data on validation or not.

#### Changes
- Existing rules are now implementing `StatelessValidationRule` instead of `ValidationRule`
- New sub-types of `FieldValidator` are introduced : `StatelessFieldValidator` and `StateBasedFieldValidator`