### PR TITLE
Dynamic Optional Flags

### DIFF
--- a/core/src/main/java/me/naingaungluu/formconductor/FieldResult.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/FieldResult.kt
@@ -1,6 +1,6 @@
 package me.naingaungluu.formconductor
 
-import me.naingaungluu.formconductor.validation.ValidationRule
+import me.naingaungluu.formconductor.validation.rules.ValidationRule
 
 /**
  * Returns after a field validation as a result

--- a/core/src/main/java/me/naingaungluu/formconductor/FormField.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/FormField.kt
@@ -31,7 +31,9 @@ interface FormField<V : Any> {
     /**
      * Optional Flag
      */
-    val isOptional: Boolean
+//    val isOptional: Boolean
+
+    fun isFieldOptional(): Boolean
 
     /**
      * Sets the value of the field

--- a/core/src/main/java/me/naingaungluu/formconductor/FormFieldImpl.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/FormFieldImpl.kt
@@ -1,9 +1,11 @@
 package me.naingaungluu.formconductor
 
 import kotlinx.coroutines.flow.MutableStateFlow
+import me.naingaungluu.formconductor.validation.optionalFlags.OptionalFlag
 import me.naingaungluu.formconductor.validation.validators.FieldValidator
 import me.naingaungluu.formconductor.validation.validators.StatelessFieldValidator
 import me.naingaungluu.formconductor.validation.rules.OptionalRule
+import me.naingaungluu.formconductor.validation.optionalFlags.RuleBasedOptionalFlag
 import kotlin.reflect.KProperty1
 
 /**
@@ -13,12 +15,12 @@ import kotlin.reflect.KProperty1
  * @param V Type of the field
  * @property fieldClass kotlin property reference to the associated property of the field
  * @property validators a set of [StatelessFieldValidator] objects associated with the field
- * @property isOptional flags the field as optional
+ * @property optionalStateEvaluators a set of [OptionalFlag] instances to evaluate if the field's optional
  */
 internal class FormFieldImpl<T : Any, V : Any>(
     private val fieldClass: KProperty1<T, V>,
     private val validators: Set<FieldValidator<V>> = emptySet(),
-    override val isOptional: Boolean = false
+    private val optionalStateEvaluators: Set<OptionalFlag> = emptySet()
 ) : FormField<V> {
 
     override val fieldName: String = fieldClass.name
@@ -46,7 +48,7 @@ internal class FormFieldImpl<T : Any, V : Any>(
         if (input != null && input != "") {
             resultStream.value = validate(input)
         } else {
-            resultStream.value = if (isOptional) {
+            resultStream.value = if (isFieldOptional()) {
                 FieldResult.Success
             } else {
                 FieldResult.Error("This field is required", OptionalRule)
@@ -75,6 +77,15 @@ internal class FormFieldImpl<T : Any, V : Any>(
         } else {
             // returns No Input when there's no error and validation fails
             error ?: FieldResult.NoInput
+        }
+    }
+
+    override fun isFieldOptional(): Boolean {
+        return if (optionalStateEvaluators.isEmpty()) {
+            // This means there's no optional flags applied
+            false
+        } else {
+            optionalStateEvaluators.all(OptionalFlag::evaluate)
         }
     }
 }

--- a/core/src/main/java/me/naingaungluu/formconductor/FormResult.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/FormResult.kt
@@ -1,6 +1,5 @@
 package me.naingaungluu.formconductor
 
-import me.naingaungluu.formconductor.validation.StatelessValidationRule
 import me.naingaungluu.formconductor.validation.ValidationRule
 
 /**

--- a/core/src/main/java/me/naingaungluu/formconductor/FormResult.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/FormResult.kt
@@ -1,6 +1,6 @@
 package me.naingaungluu.formconductor
 
-import me.naingaungluu.formconductor.validation.ValidationRule
+import me.naingaungluu.formconductor.validation.rules.ValidationRule
 
 /**
  * Form result object with multiple states

--- a/core/src/main/java/me/naingaungluu/formconductor/annotations/DynamicOptional.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/annotations/DynamicOptional.kt
@@ -1,0 +1,11 @@
+package me.naingaungluu.formconductor.annotations
+
+import me.naingaungluu.formconductor.validation.rules.OptionalStateRule
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+annotation class DynamicOptional(
+    val evaluator: KClass<out OptionalStateRule<*>>
+)

--- a/core/src/main/java/me/naingaungluu/formconductor/annotations/FieldValidation.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/annotations/FieldValidation.kt
@@ -1,6 +1,5 @@
 package me.naingaungluu.formconductor.annotations
 
-import me.naingaungluu.formconductor.validation.StatelessValidationRule
 import me.naingaungluu.formconductor.validation.ValidationRule
 import kotlin.reflect.KClass
 

--- a/core/src/main/java/me/naingaungluu/formconductor/annotations/FieldValidation.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/annotations/FieldValidation.kt
@@ -1,6 +1,6 @@
 package me.naingaungluu.formconductor.annotations
 
-import me.naingaungluu.formconductor.validation.ValidationRule
+import me.naingaungluu.formconductor.validation.rules.ValidationRule
 import kotlin.reflect.KClass
 
 /**

--- a/core/src/main/java/me/naingaungluu/formconductor/builder/FormFieldFactory.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/builder/FormFieldFactory.kt
@@ -1,0 +1,59 @@
+package me.naingaungluu.formconductor.builder
+
+import me.naingaungluu.formconductor.CollectableFormData
+import me.naingaungluu.formconductor.FormField
+import me.naingaungluu.formconductor.FormFieldImpl
+import me.naingaungluu.formconductor.annotations.DynamicOptional
+import me.naingaungluu.formconductor.utils.*
+import me.naingaungluu.formconductor.validation.optionalFlags.DefaultOptionalFlag
+import me.naingaungluu.formconductor.validation.optionalFlags.OptionalFlag
+import me.naingaungluu.formconductor.validation.validators.FieldValidator
+import me.naingaungluu.formconductor.validation.optionalFlags.RuleBasedOptionalFlag
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.*
+
+internal class FormFieldFactory<T: Any> (
+    private val form: CollectableFormData<T>
+) {
+
+    /**
+     * Factory instance for [FieldValidator] classes
+     */
+    private val fieldValidatorFactory: FormFieldValidatorFactory<T> by lazy {
+        FormFieldValidatorFactory(form)
+    }
+
+    /**
+     * A factory method that receives the property reference and constructs [FormField] object
+     *
+     * @param field kotlin property reference to the field
+     * @return [FormField] instance ready to operate with
+     */
+    fun create(field: KProperty1<T, *>): FormField<Any> {
+
+        // Create field validators
+        val validators = field
+            .validationAnnotations()
+            .map(fieldValidatorFactory::create)
+            .toSet()
+
+        val optionalFlagEvaluators: Set<OptionalFlag> = if (field.hasAnnotation<DynamicOptional>()) {
+            field.findAnnotations<DynamicOptional>()
+                .map {
+                    RuleBasedOptionalFlag(form, it.getEvaluatorInstance())
+                }
+                .toSet()
+
+        } else {
+            setOf(
+                DefaultOptionalFlag(field.isFieldOptional())
+            )
+        }
+
+        return FormFieldImpl(
+            fieldClass = field as KProperty1<T, Any>,
+            validators = validators,
+            optionalStateEvaluators = optionalFlagEvaluators
+        )
+    }
+}

--- a/core/src/main/java/me/naingaungluu/formconductor/builder/FormFieldValidatorFactory.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/builder/FormFieldValidatorFactory.kt
@@ -1,0 +1,44 @@
+package me.naingaungluu.formconductor.builder
+
+import me.naingaungluu.formconductor.CollectableFormData
+import me.naingaungluu.formconductor.annotations.FieldValidation
+import me.naingaungluu.formconductor.annotations.MaxLength
+import me.naingaungluu.formconductor.utils.getFieldValidationData
+import me.naingaungluu.formconductor.validation.rules.StateBasedValidationRule
+import me.naingaungluu.formconductor.validation.rules.StatelessValidationRule
+import me.naingaungluu.formconductor.validation.validators.FieldValidator
+import me.naingaungluu.formconductor.validation.validators.StateBasedFieldValidator
+import me.naingaungluu.formconductor.validation.validators.StatelessFieldValidator
+
+internal class FormFieldValidatorFactory<T: Any>(
+    private val form: CollectableFormData<T>
+) {
+    fun create(
+        validatorOptions: Annotation
+    ): FieldValidator<Any> {
+        val fieldValidationAnnotation: FieldValidation = validatorOptions.getFieldValidationData()
+        return when (
+            val validationRule = fieldValidationAnnotation.validator.objectInstance
+        ) {
+            is StatelessValidationRule<*, *> ->
+                StatelessFieldValidator(
+                    validationRule = validationRule as StatelessValidationRule<Any, Annotation>,
+                    options = validatorOptions
+                )
+            is StateBasedValidationRule<*, *, *> ->
+                StateBasedFieldValidator(
+                    validationRule = validationRule as StateBasedValidationRule<Any, Annotation, T>,
+                    options = validatorOptions,
+                    form = form
+                )
+            else -> {
+                throw IllegalArgumentException(
+                    """
+                        |Incompatible Validation Rule type ${fieldValidationAnnotation.validator.simpleName} is provided
+                        |for annotation ${validatorOptions.annotationClass.simpleName}
+                    """.trimMargin()
+                )
+            }
+        }
+    }
+}

--- a/core/src/main/java/me/naingaungluu/formconductor/utils/ReflectionExtensions.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/utils/ReflectionExtensions.kt
@@ -1,0 +1,31 @@
+package me.naingaungluu.formconductor.utils
+
+import me.naingaungluu.formconductor.annotations.DynamicOptional
+import me.naingaungluu.formconductor.annotations.FieldValidation
+import me.naingaungluu.formconductor.annotations.Optional
+import me.naingaungluu.formconductor.validation.rules.OptionalStateRule
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.hasAnnotation
+
+inline fun <T: Any, reified V:Annotation> KProperty1<T,V>.isAnnotatedWith(annotation: KClass<V>): Boolean {
+    return this.hasAnnotation<V>()
+}
+
+fun <T: Any> KProperty1<T, *>.isFieldOptional() : Boolean = hasAnnotation<Optional>()
+
+fun <T: Any> KProperty1<T, *>.validationAnnotations() = annotations.filter(Annotation::isFieldValidation)
+
+fun Annotation.isFieldValidation() = annotationClass.hasAnnotation<FieldValidation>()
+
+fun Annotation.getFieldValidationData() : FieldValidation =
+    requireNotNull(annotationClass.findAnnotation<FieldValidation>()) {
+        "${this.annotationClass.simpleName} must be annotated with @FieldValidation"
+    }
+
+
+fun <T: Any> DynamicOptional.getEvaluatorInstance() : OptionalStateRule<T> =
+    requireNotNull(evaluator.objectInstance as? OptionalStateRule<T>) {
+        "Unable to get instance of class ${evaluator.simpleName}"
+    }

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/ValidationRule.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/ValidationRule.kt
@@ -1,3 +1,0 @@
-package me.naingaungluu.formconductor.validation
-
-interface ValidationRule

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/optionalFlags/DefaultOptionalFlag.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/optionalFlags/DefaultOptionalFlag.kt
@@ -1,0 +1,10 @@
+package me.naingaungluu.formconductor.validation.optionalFlags
+
+import me.naingaungluu.formconductor.utils.isFieldOptional
+import kotlin.reflect.KProperty1
+
+class DefaultOptionalFlag(
+    private val isOptional: Boolean
+): OptionalFlag {
+    override fun evaluate(): Boolean = isOptional
+}

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/optionalFlags/OptionalFlag.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/optionalFlags/OptionalFlag.kt
@@ -1,0 +1,5 @@
+package me.naingaungluu.formconductor.validation.optionalFlags
+
+interface OptionalFlag {
+    fun evaluate(): Boolean
+}

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/optionalFlags/RuleBasedOptionalFlag.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/optionalFlags/RuleBasedOptionalFlag.kt
@@ -1,0 +1,13 @@
+package me.naingaungluu.formconductor.validation.optionalFlags
+
+import me.naingaungluu.formconductor.CollectableFormData
+import me.naingaungluu.formconductor.validation.rules.OptionalStateRule
+
+internal class RuleBasedOptionalFlag<T: Any>(
+    private val formState: CollectableFormData<T>,
+    private val rule: OptionalStateRule<T>
+) : OptionalFlag {
+    override fun evaluate(): Boolean {
+        return rule.isOptional(formState.collectFormData())
+    }
+}

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/rules/EmailAddressRule.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/rules/EmailAddressRule.kt
@@ -2,7 +2,6 @@ package me.naingaungluu.formconductor.validation.rules
 
 import me.naingaungluu.formconductor.FieldResult
 import me.naingaungluu.formconductor.annotations.EmailAddress
-import me.naingaungluu.formconductor.validation.StatelessValidationRule
 
 /**
  * Validation Rule for Email Addresses

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/rules/FloatRangeRule.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/rules/FloatRangeRule.kt
@@ -2,7 +2,6 @@ package me.naingaungluu.formconductor.validation.rules
 
 import me.naingaungluu.formconductor.FieldResult
 import me.naingaungluu.formconductor.annotations.FloatRange
-import me.naingaungluu.formconductor.validation.StatelessValidationRule
 
 /**
  * Validation Rule for Ranged Float Values

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/rules/IntegerRangeRule.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/rules/IntegerRangeRule.kt
@@ -3,7 +3,6 @@ package me.naingaungluu.formconductor.validation.rules
 import me.naingaungluu.formconductor.FieldResult
 import me.naingaungluu.formconductor.annotations.FloatRange
 import me.naingaungluu.formconductor.annotations.IntegerRange
-import me.naingaungluu.formconductor.validation.StatelessValidationRule
 
 /**
  * Validation Rule for Ranged Integer Values

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/rules/IsCheckedRule.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/rules/IsCheckedRule.kt
@@ -2,7 +2,6 @@ package me.naingaungluu.formconductor.validation.rules
 
 import me.naingaungluu.formconductor.FieldResult
 import me.naingaungluu.formconductor.annotations.IsChecked
-import me.naingaungluu.formconductor.validation.StatelessValidationRule
 
 /**
  * Validation Rule for Checkboxes

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/rules/MaxLengthRule.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/rules/MaxLengthRule.kt
@@ -2,7 +2,6 @@ package me.naingaungluu.formconductor.validation.rules
 
 import me.naingaungluu.formconductor.FieldResult
 import me.naingaungluu.formconductor.annotations.MaxLength
-import me.naingaungluu.formconductor.validation.StatelessValidationRule
 
 /**
  * Validation Rule for String Lengths

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/rules/MinLengthRule.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/rules/MinLengthRule.kt
@@ -3,7 +3,6 @@ package me.naingaungluu.formconductor.validation.rules
 import me.naingaungluu.formconductor.FieldResult
 import me.naingaungluu.formconductor.annotations.MaxLength
 import me.naingaungluu.formconductor.annotations.MinLength
-import me.naingaungluu.formconductor.validation.StatelessValidationRule
 
 /**
  * Validation Rule for String Lengths

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/rules/OptionalRule.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/rules/OptionalRule.kt
@@ -2,7 +2,6 @@ package me.naingaungluu.formconductor.validation.rules
 
 import me.naingaungluu.formconductor.FieldResult
 import me.naingaungluu.formconductor.annotations.Optional
-import me.naingaungluu.formconductor.validation.StatelessValidationRule
 
 /**
  * Validation Rule for Optional Fields

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/rules/OptionalStateRule.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/rules/OptionalStateRule.kt
@@ -1,0 +1,5 @@
+package me.naingaungluu.formconductor.validation.rules
+
+interface OptionalStateRule<T> {
+    fun isOptional(state: T): Boolean
+}

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/rules/StateBasedValidationRule.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/rules/StateBasedValidationRule.kt
@@ -1,4 +1,4 @@
-package me.naingaungluu.formconductor.validation
+package me.naingaungluu.formconductor.validation.rules
 
 import me.naingaungluu.formconductor.FieldResult
 

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/rules/StatelessValidationRule.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/rules/StatelessValidationRule.kt
@@ -1,4 +1,4 @@
-package me.naingaungluu.formconductor.validation
+package me.naingaungluu.formconductor.validation.rules
 
 import me.naingaungluu.formconductor.FieldResult
 

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/rules/ValidationRule.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/rules/ValidationRule.kt
@@ -1,0 +1,3 @@
+package me.naingaungluu.formconductor.validation.rules
+
+interface ValidationRule

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/rules/WebUrlRule.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/rules/WebUrlRule.kt
@@ -4,7 +4,6 @@ import me.naingaungluu.formconductor.FieldResult
 import me.naingaungluu.formconductor.annotations.MaxLength
 import me.naingaungluu.formconductor.annotations.MinLength
 import me.naingaungluu.formconductor.annotations.WebUrl
-import me.naingaungluu.formconductor.validation.StatelessValidationRule
 
 /**
  * Validation Rule for String Lengths

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/validators/FieldValidator.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/validators/FieldValidator.kt
@@ -2,6 +2,6 @@ package me.naingaungluu.formconductor.validation.validators
 
 import me.naingaungluu.formconductor.FieldResult
 
-internal abstract class FieldValidator<V: Any?> {
-    abstract fun validate(input: V): FieldResult
+internal interface FieldValidator<V: Any?> {
+    fun validate(input: V): FieldResult
 }

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/validators/StateBasedFieldValidator.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/validators/StateBasedFieldValidator.kt
@@ -2,7 +2,7 @@ package me.naingaungluu.formconductor.validation.validators
 
 import me.naingaungluu.formconductor.CollectableFormData
 import me.naingaungluu.formconductor.FieldResult
-import me.naingaungluu.formconductor.validation.StateBasedValidationRule
+import me.naingaungluu.formconductor.validation.rules.StateBasedValidationRule
 
 /**
  * This is a wrapper class for a [StateBasedValidationRule] instance.
@@ -21,7 +21,7 @@ internal class StateBasedFieldValidator<T: Any, V: Any?, A: Annotation>(
     private val form: CollectableFormData<T>,
     private val validationRule: StateBasedValidationRule<V, A, T>,
     private val options: A
-) : FieldValidator<V>() {
+) : FieldValidator<V> {
     override fun validate(input: V): FieldResult {
         return validationRule.validate(input, options, form.collectFormData())
     }

--- a/core/src/main/java/me/naingaungluu/formconductor/validation/validators/StatelessFieldValidator.kt
+++ b/core/src/main/java/me/naingaungluu/formconductor/validation/validators/StatelessFieldValidator.kt
@@ -1,7 +1,7 @@
 package me.naingaungluu.formconductor.validation.validators
 
 import me.naingaungluu.formconductor.FieldResult
-import me.naingaungluu.formconductor.validation.StatelessValidationRule
+import me.naingaungluu.formconductor.validation.rules.StatelessValidationRule
 
 /**
  * A wrapper class or proxy that passes the annotation object as options to the validation rule
@@ -18,7 +18,7 @@ import me.naingaungluu.formconductor.validation.StatelessValidationRule
 internal class StatelessFieldValidator<V : Any?, A : Annotation>(
     private val validationRule: StatelessValidationRule<V, A>,
     private val options: A
-) : FieldValidator<V>() {
+) : FieldValidator<V> {
     /**
      * Validates the field using just it's value, since the option is known
      *


### PR DESCRIPTION
We can now annotate properties whose optional flag is evaluated based on the values of the form.
We're using `@DynamicOptional` annotation together with `RuleBasedOptionalFlag` evaluators